### PR TITLE
Fix test for WSS 

### DIFF
--- a/tests/testthat/testWSS.r
+++ b/tests/testthat/testWSS.r
@@ -39,6 +39,6 @@ test_that("Test WSS2", {
 
                  "year.stderror", "intercept.zvalue", "year.zvalue", "intercept.pvalue", 
                  "year.pvalue", "observations"))
-  expect_equal(nrow(results), 24)
+  expect_equal(nrow(results), 25)
   
 })


### PR DESCRIPTION
Yesterday it was failing because `results` had 24 rows... Not sure what happened.