### PR TITLE
allow reportingRateModel to take a numeric vector of time periods. ex…

### DIFF
--- a/R/reportingRateModel.r
+++ b/R/reportingRateModel.r
@@ -5,9 +5,12 @@
 #' @param taxa A character vector of taxon names, as long as the number of observations.
 #' @param site A character vector of site names, as long as the number of observations.
 #' @param time_period A numeric vector of user defined time periods, or a date vector,
-#'        as long as the number of observations.
+#'        as long as the number of observations. Dates should be used where one wants to fit models at the "visit"
+#'        (typically one day) level. To fit models at coarser temporal resolutions then \code{time_period} 
+#'        should be numeric. Note that duplicae site x time_period x species records are dropped, so
+#'        your data will be substantially degraded if broad time periods are used. 
 #' @param list_length Logical, if \code{TRUE} then list length is added to the models as a fixed
-#'        effect. Note that since list_length is a property of each visit the model will run as 
+#'        effect. Note that since list_length is a property of each visit (or coarser period) the model will run as 
 #'        a binomial model rather that as a bernoulli model.
 #' @param site_effect Logical, if \code{TRUE} then site is added to the models as a random
 #'        effect.
@@ -171,6 +174,3 @@ reportingRateModel <- function(taxa, site, time_period, list_length = FALSE, sit
   
   return(coef_df)
 }
-
-
-

--- a/tests/testthat/testreportingRateModel.r
+++ b/tests/testthat/testreportingRateModel.r
@@ -22,17 +22,24 @@ site <- sample(paste('A', 1:nSites, sep=''), size = n, TRUE)
 # the date of visit is selected at random from those created earlier
 time_period <- sample(rDates, size = n, TRUE)
 
+# create a numeric vector of time periods to test for
+num_period <- as.numeric(format(time_period,'%Y'))
+
+# create additional dates with month and dat = 01 in to test if numeric and date format time_periods give equivalent results
+dates <- as.POSIXct(strptime(paste0(num_period, "/01/01"), "%Y/%m/%d")) 
+
 # combine this to a dataframe (adding a final row of 'bad' data)
 df <- data.frame(taxa = c(taxa,'bad'),
                  site = c(site,'A1'),
-                 time_period = c(time_period, as.POSIXct(strptime("1200/01/01", "%Y/%m/%d"))))
+                 time_period = c(time_period, as.POSIXct(strptime("1200/01/01", "%Y/%m/%d"))),
+                 num_period = c(num_period, 1200),
+                 comparison_dates = c(dates, as.POSIXct(strptime("1200/01/01", "%Y/%m/%d"))))
 
 ######################
 test_that("Test errors and warnings", {
   
   # outside errorChecks this is the only catch present in this set of functions
-  #expect_error(RR_out <- reportingRateModel(df$taxa, df$site, 1:length(df$time_period)),
-  #             "non-dates not yet supported for time_period")
+
   # A couple in errorChecks for this function
   # warning when family is overridden by listlength
   expect_warning(RR_out <- reportingRateModel(df$taxa,
@@ -69,7 +76,7 @@ test_that("Test errors and warnings", {
 })
 
 test_that("Test formulaBuilder", {
-  
+
     
   family <- 'binomial'
   list_length <- FALSE
@@ -104,5 +111,9 @@ test_that("Check outputs are in the correct form", {
   expect_equal(atts$model_formula, "cbind(successes, failures) ~ year")
   expect_is(RR_out, "data.frame")
   expect_identical(c('a','b','c'), sort(as.character(RR_out$species_name)))
+  ## check outputs are equal when time_periods are numeric or in date format
+  expect_equal(reportingRateModel(df$taxa, df$site, df$num_period, species_to_include = c('a','b','c')), 
+               reportingRateModel(df$taxa, df$site, df$num_period, species_to_include = c('a','b','c')))
 
 })
+

--- a/tests/testthat/testreportingRateModel.r
+++ b/tests/testthat/testreportingRateModel.r
@@ -31,8 +31,8 @@ df <- data.frame(taxa = c(taxa,'bad'),
 test_that("Test errors and warnings", {
   
   # outside errorChecks this is the only catch present in this set of functions
-  expect_error(RR_out <- reportingRateModel(df$taxa, df$site, 1:length(df$time_period)),
-               "non-dates not yet supported for time_period")
+  #expect_error(RR_out <- reportingRateModel(df$taxa, df$site, 1:length(df$time_period)),
+  #             "non-dates not yet supported for time_period")
   # A couple in errorChecks for this function
   # warning when family is overridden by listlength
   expect_warning(RR_out <- reportingRateModel(df$taxa,


### PR DESCRIPTION
…pect_error test removed to reflect that the function should no longer return an error when time_periods are not in date format